### PR TITLE
[Style] 전체적인 UI 수정

### DIFF
--- a/src/pages/CaptainGamePage.jsx
+++ b/src/pages/CaptainGamePage.jsx
@@ -139,14 +139,15 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7.1vh 7.5vw 0 7.5vw;
+  padding: 7.5vh 0 0 0;
 `;
 
 const ExitButton = styled.button`
+  width: 2.8vw;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0 0 7.5vw ;
   img {
     width: 3vw;
   }
@@ -155,6 +156,9 @@ const ExitButton = styled.button`
 const Counter = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 3.3vw;
+  position: absolute;
+  left: 50%; 
+  transform: translateX(-50%);
 `;
 
 const Content = styled.div`

--- a/src/pages/CaptainGamePage.jsx
+++ b/src/pages/CaptainGamePage.jsx
@@ -100,7 +100,7 @@ const CaptainGamePage = () => {
         <div style={{ width: '48px' }} />
       </Header>
       <Content>
-        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0}>
+        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0} chevron="left">
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
@@ -110,7 +110,7 @@ const CaptainGamePage = () => {
               : cards[currentCardIndex].name}
           </Card>
         </CardContainer>
-        <NavButton onClick={handleNext}>
+        <NavButton onClick={handleNext} chevron="right">
           <img src="/images/icon_chevron_right.png" alt="next" />
         </NavButton>
       </Content>
@@ -172,10 +172,15 @@ const NavButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  position: absolute;
+
   img {
-    width: 5vw;
+    height: 9.3vh;
   }
+    
+  ${(props) => props.chevron === 'left' && `left: 8vw;`}
+  ${(props) => props.chevron === 'right' && `right: 8vw;`}
+
   &:disabled {
     cursor: default;
     opacity: 0.5;

--- a/src/pages/CaptainGamePage.jsx
+++ b/src/pages/CaptainGamePage.jsx
@@ -165,7 +165,6 @@ const Content = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-grow: 1;
 `;
 
 const NavButton = styled.button`
@@ -173,6 +172,8 @@ const NavButton = styled.button`
   border: none;
   cursor: pointer;
   position: absolute;
+  top: 50%; 
+  transform: translateY(-50%);
 
   img {
     height: 9.3vh;
@@ -188,13 +189,13 @@ const NavButton = styled.button`
 `;
 
 const CardContainer = styled.div`
-  width: 70vw;
-  height: 40vh;
+  width: 65vw;
+  height: 25.9vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 20px;
+  padding: 23.4vh 0 0 0;
+
 `;
 
 const Card = styled.div`
@@ -206,8 +207,9 @@ const Card = styled.div`
 `;
 
 const AnswerButton = styled.button`
-  width: 17.3vw;
+  width: 19.5vw;
   height: 8.5vh;
+  margin-top: 16vh;
   background-color: ${(props) => (props.$isAnswered ? 'white' : '#ff62d3')};
   border: none;
   border-radius: 12px;
@@ -215,5 +217,4 @@ const AnswerButton = styled.button`
   font-size: 3vw;
   color: black;
   cursor: pointer;
-  margin-bottom: 10vh;
 `;

--- a/src/pages/CategoryPage.jsx
+++ b/src/pages/CategoryPage.jsx
@@ -130,18 +130,21 @@ const Content = styled.div`
 
 const CategoryRow = styled.div`
   display: flex;
-  margin-left: 8.5vw;
+  gap: 3.6vw; 
 `;
 
 const CategoryButton = styled.div`
   position: relative;
   width: 19vw;
   height: 56vh;
-  margin-right: 2.4vw;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
+  border-radius: 24px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+
 `;
 
 const CategoryImg = styled.img`

--- a/src/pages/CategoryPage.jsx
+++ b/src/pages/CategoryPage.jsx
@@ -44,8 +44,10 @@ const CategoryPage = () => {
   return (
     <Container onKeyDown={handleKeyDown} tabIndex="0" ref={focusRef}>
       <Header>
-        <TitleImage src="/images/title.png" alt="title" onClick={() => navigate(-1)} />
-      </Header>
+        <ExitButton onClick={() => navigate(-1)}>
+          <img src="/images/Exit.png" alt="exit" />
+        </ExitButton>
+        \      </Header>
       <Content>
         <CategoryRow>
           <CategoryButton
@@ -102,14 +104,20 @@ const Container = styled.div`
 const Header = styled.div`
   width: 100%;
   display: flex;
-  justify-content: flex-start;
-  padding: 5.6vh 8.4vw 0 8.4vw;
+  justify-content: space-between;
+  align-items: center;
+  padding: 7.5vh 0 0 0;
 `;
 
-const TitleImage = styled.img`
-  width: 15vw;
-  height: 3.8vh;
+const ExitButton = styled.button`
+  width: 2.8vw;
+  background: none;
+  border: none;
   cursor: pointer;
+  padding: 0 0 0 7.5vw ;
+  img {
+    width: 3vw;
+  }
 `;
 
 const Content = styled.div`

--- a/src/pages/ChoiGamePage.jsx
+++ b/src/pages/ChoiGamePage.jsx
@@ -122,14 +122,15 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7.1vh 7.5vw 0 7.5vw;
+  padding: 7.5vh 0 0 0;
 `;
 
 const ExitButton = styled.button`
+  width: 2.8vw;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0 0 7.5vw ;
   img {
     width: 3vw;
   }
@@ -138,6 +139,9 @@ const ExitButton = styled.button`
 const Counter = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 3.3vw;
+  position: absolute;
+  left: 50%; 
+  transform: translateX(-50%);
 `;
 
 const Content = styled.div`

--- a/src/pages/ChoiGamePage.jsx
+++ b/src/pages/ChoiGamePage.jsx
@@ -148,7 +148,6 @@ const Content = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-grow: 1;
 `;
 
 const NavButton = styled.button`
@@ -156,6 +155,8 @@ const NavButton = styled.button`
   border: none;
   cursor: pointer;
   position: absolute;
+  top: 50%; 
+  transform: translateY(-50%);
 
   img {
     height: 9.3vh;
@@ -171,13 +172,12 @@ const NavButton = styled.button`
 `;
 
 const CardContainer = styled.div`
-  width: 63vw;
-  height: 40vh;
+  width: 34.7vw;
+  height: 24.2vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 20px;
+  padding: 25.7vh 0 0 0;
 `;
 
 const Card = styled.div`

--- a/src/pages/ChoiGamePage.jsx
+++ b/src/pages/ChoiGamePage.jsx
@@ -90,13 +90,13 @@ const ChoiGamePage = () => {
         <div style={{ width: '48px' }} />
       </Header>
       <Content>
-        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0}>
+        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0} chevron="left">
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
           <Card>{cards[currentCardIndex].name}</Card>
         </CardContainer>
-        <NavButton onClick={handleNext}>
+        <NavButton onClick={handleNext} chevron="right">
           <img src="/images/icon_chevron_right.png" alt="next" />
         </NavButton>
       </Content>
@@ -155,10 +155,15 @@ const NavButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  position: absolute;
+
   img {
-    width: 5vw;
+    height: 9.3vh;
   }
+    
+  ${(props) => props.chevron === 'left' && `left: 8vw;`}
+  ${(props) => props.chevron === 'right' && `right: 8vw;`}
+
   &:disabled {
     cursor: default;
     opacity: 0.5;

--- a/src/pages/DiscoGamePage.jsx
+++ b/src/pages/DiscoGamePage.jsx
@@ -122,14 +122,15 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7.1vh 7.5vw 0 7.5vw;
+  padding: 7.5vh 0 0 0;
 `;
 
 const ExitButton = styled.button`
+  width: 2.8vw;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0 0 7.5vw ;
   img {
     width: 3vw;
   }
@@ -138,6 +139,9 @@ const ExitButton = styled.button`
 const Counter = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 3.3vw;
+  position: absolute;
+  left: 50%; 
+  transform: translateX(-50%);
 `;
 
 const Content = styled.div`

--- a/src/pages/DiscoGamePage.jsx
+++ b/src/pages/DiscoGamePage.jsx
@@ -148,7 +148,6 @@ const Content = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-grow: 1;
 `;
 
 const NavButton = styled.button`
@@ -156,6 +155,8 @@ const NavButton = styled.button`
   border: none;
   cursor: pointer;
   position: absolute;
+  top: 50%; 
+  transform: translateY(-50%);
 
   img {
     height: 9.3vh;
@@ -171,17 +172,16 @@ const NavButton = styled.button`
 `;
 
 const CardContainer = styled.div`
-  width: 63vw;
-  height: 40vh;
+  height: 24.2vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 20px;
+  padding: 25.7vh 0 0 0;
 `;
 
 const Card = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 10.8vw;
+  // font-size: 24.2vw;
   color: white;
 `;

--- a/src/pages/DiscoGamePage.jsx
+++ b/src/pages/DiscoGamePage.jsx
@@ -90,13 +90,13 @@ const DiscoGamePage = () => {
         <div style={{ width: '48px' }} />
       </Header>
       <Content>
-        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0}>
+        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0} chevron="left">
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
           <Card>{cards[currentCardIndex].name}</Card>
         </CardContainer>
-        <NavButton onClick={handleNext}>
+        <NavButton onClick={handleNext} chevron="right">
           <img src="/images/icon_chevron_right.png" alt="next" />
         </NavButton>
       </Content>
@@ -155,10 +155,15 @@ const NavButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  position: absolute;
+
   img {
-    width: 5vw;
+    height: 9.3vh;
   }
+    
+  ${(props) => props.chevron === 'left' && `left: 8vw;`}
+  ${(props) => props.chevron === 'right' && `right: 8vw;`}
+
   &:disabled {
     cursor: default;
     opacity: 0.5;

--- a/src/pages/FourGamePage.jsx
+++ b/src/pages/FourGamePage.jsx
@@ -135,7 +135,6 @@ const Content = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-grow: 1;
 `;
 
 const NavButton = styled.button`
@@ -143,6 +142,8 @@ const NavButton = styled.button`
   border: none;
   cursor: pointer;
   position: absolute;
+  top: 50%; 
+  transform: translateY(-50%);
 
   img {
     height: 9.3vh;
@@ -158,13 +159,12 @@ const NavButton = styled.button`
 `;
 
 const CardContainer = styled.div`
-  width: 63vw;
-  height: 40vh;
+  width: 47vw;
+  height: 18.7;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 20px;
+  padding: 28.4vh 0 0 0;
 `;
 
 const Card = styled.div`

--- a/src/pages/FourGamePage.jsx
+++ b/src/pages/FourGamePage.jsx
@@ -77,13 +77,13 @@ const FourGamePage = () => {
         <div style={{ width: '48px' }} />
       </Header>
       <Content>
-        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0}>
+        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0} chevron="left">
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
           <Card>{cards[currentCardIndex].name}</Card>
         </CardContainer>
-        <NavButton onClick={handleNext}>
+        <NavButton onClick={handleNext} chevron="right">
           <img src="/images/icon_chevron_right.png" alt="next" />
         </NavButton>
       </Content>
@@ -142,10 +142,15 @@ const NavButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  position: absolute;
+
   img {
-    width: 5vw;
+    height: 9.3vh;
   }
+    
+  ${(props) => props.chevron === 'left' && `left: 8vw;`}
+  ${(props) => props.chevron === 'right' && `right: 8vw;`}
+
   &:disabled {
     cursor: default;
     opacity: 0.5;

--- a/src/pages/FourGamePage.jsx
+++ b/src/pages/FourGamePage.jsx
@@ -109,14 +109,15 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7.1vh 7.5vw 0 7.5vw;
+  padding: 7.5vh 0 0 0;
 `;
 
 const ExitButton = styled.button`
+  width: 2.8vw;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0 0 7.5vw ;
   img {
     width: 3vw;
   }
@@ -125,6 +126,9 @@ const ExitButton = styled.button`
 const Counter = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 3.3vw;
+  position: absolute;
+  left: 50%; 
+  transform: translateX(-50%);
 `;
 
 const Content = styled.div`

--- a/src/pages/MovieGamePage.jsx
+++ b/src/pages/MovieGamePage.jsx
@@ -102,7 +102,7 @@ const MovieGamePage = () => {
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
-          <Card>
+          <Card isAnswered={isAnswered}>
             {isAnswered ? (
               <AnswerText>{cards[currentCardIndex].answer}</AnswerText>
             ) : (
@@ -165,7 +165,6 @@ const Content = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-grow: 1;
 `;
 
 const NavButton = styled.button`
@@ -173,6 +172,8 @@ const NavButton = styled.button`
   border: none;
   cursor: pointer;
   position: absolute;
+  top: 50%; 
+  transform: translateY(-50%);
 
   img {
     height: 9.3vh;
@@ -188,32 +189,28 @@ const NavButton = styled.button`
 `;
 
 const CardContainer = styled.div`
-  width: 70vw;
-  height: 67vh;
+  height: 54.1vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 20px;
-  overflow: hidden;
+  padding: ${(props) => (props.isAnswered ? '30vh 0 0 0' : '6.1vh 0 0 0')};
 `;
 
 const Card = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 100%;
   height: 100%;
 `;
 
 const CardImage = styled.img`
-  width: 100%;
   height: 100%;
   object-fit: contain;
   display: block;
 `;
 
 const AnswerText = styled.p`
+  height: 12.9vh;
   font-family: 'DungGeunMo', sans-serif;
   font-size: 6vw;
   color: #ff62d3;
@@ -222,7 +219,7 @@ const AnswerText = styled.p`
 `;
 
 const AnswerButton = styled.button`
-  width: 17.3vw;
+  width: 19.5vw;
   height: 8.5vh;
   background-color: ${(props) => (props.isAnswered ? 'white' : '#ff62d3')};
   border: none;
@@ -231,5 +228,5 @@ const AnswerButton = styled.button`
   font-size: 3vw;
   color: black;
   cursor: pointer;
-  margin-bottom: 3.8vh;
+  margin-top: 5.1vh;
 `;

--- a/src/pages/MovieGamePage.jsx
+++ b/src/pages/MovieGamePage.jsx
@@ -139,14 +139,15 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7.1vh 7.5vw 0 7.5vw;
+  padding: 7.5vh 0 0 0;
 `;
 
 const ExitButton = styled.button`
+  width: 2.8vw;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0 0 7.5vw ;
   img {
     width: 3vw;
   }
@@ -155,6 +156,9 @@ const ExitButton = styled.button`
 const Counter = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 3.3vw;
+  position: absolute;
+  left: 50%; 
+  transform: translateX(-50%);
 `;
 
 const Content = styled.div`

--- a/src/pages/MovieGamePage.jsx
+++ b/src/pages/MovieGamePage.jsx
@@ -98,7 +98,7 @@ const MovieGamePage = () => {
         <div style={{ width: '48px' }} />
       </Header>
       <Content>
-        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0}>
+        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0} chevron="left">
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
@@ -110,7 +110,7 @@ const MovieGamePage = () => {
             )}
           </Card>
         </CardContainer>
-        <NavButton onClick={handleNext}>
+        <NavButton onClick={handleNext} chevron="right">
           <img src="/images/icon_chevron_right.png" alt="next" />
         </NavButton>
       </Content>
@@ -172,10 +172,15 @@ const NavButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  position: absolute;
+
   img {
-    width: 5vw;
+    height: 9.3vh;
   }
+    
+  ${(props) => props.chevron === 'left' && `left: 8vw;`}
+  ${(props) => props.chevron === 'right' && `right: 8vw;`}
+
   &:disabled {
     cursor: default;
     opacity: 0.5;

--- a/src/pages/MusicTitleGamePage.jsx
+++ b/src/pages/MusicTitleGamePage.jsx
@@ -142,7 +142,7 @@ const MusicTitleGamePage = () => {
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
-          <Card>
+          <Card isAnswered={isAnswered}>
             {isAnswered
               ? cards[currentCardIndex].answer
               : getQuestionText(cards[currentCardIndex])}
@@ -203,7 +203,6 @@ const Content = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-grow: 1;
 `;
 
 const NavButton = styled.button`
@@ -211,6 +210,8 @@ const NavButton = styled.button`
   border: none;
   cursor: pointer;
   position: absolute;
+  top: 50%; 
+  transform: translateY(-50%);
 
   img {
     height: 9.3vh;
@@ -227,24 +228,23 @@ const NavButton = styled.button`
 
 const CardContainer = styled.div`
   width: 63vw;
-  height: 60vh;
+  height: 12.9vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 20px;
+  padding: 29.9vh 0 0 0;
 `;
 
 const Card = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 6.5vw;
-  color: white;
+  color: ${(props) => (props.isAnswered ? '#ff62d3' : 'white')};
   white-space: pre-wrap;
   text-align: center;
 `;
 
 const AnswerButton = styled.button`
-  width: 17.3vw;
+  width: 19.5vw;
   height: 8.5vh;
   background-color: ${(props) => (props.isAnswered ? 'white' : '#ff62d3')};
   border: none;
@@ -253,5 +253,5 @@ const AnswerButton = styled.button`
   font-size: 3vw;
   color: black;
   cursor: pointer;
-  margin-bottom: 13.2vh;
+  margin-top: 22.4vh;
 `;

--- a/src/pages/MusicTitleGamePage.jsx
+++ b/src/pages/MusicTitleGamePage.jsx
@@ -138,7 +138,7 @@ const MusicTitleGamePage = () => {
         <div style={{ width: '48px' }} />
       </Header>
       <Content>
-        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0}>
+        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0} chevron="left">
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
@@ -148,7 +148,7 @@ const MusicTitleGamePage = () => {
               : getQuestionText(cards[currentCardIndex])}
           </Card>
         </CardContainer>
-        <NavButton onClick={handleNext}>
+        <NavButton onClick={handleNext} chevron="right">
           <img src="/images/icon_chevron_right.png" alt="next" />
         </NavButton>
       </Content>
@@ -210,10 +210,15 @@ const NavButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  position: absolute;
+
   img {
-    width: 5vw;
+    height: 9.3vh;
   }
+    
+  ${(props) => props.chevron === 'left' && `left: 8vw;`}
+  ${(props) => props.chevron === 'right' && `right: 8vw;`}
+
   &:disabled {
     cursor: default;
     opacity: 0.5;

--- a/src/pages/MusicTitleGamePage.jsx
+++ b/src/pages/MusicTitleGamePage.jsx
@@ -177,14 +177,15 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7.1vh 7.5vw 0 7.5vw;
+  padding: 7.5vh 0 0 0;
 `;
 
 const ExitButton = styled.button`
+  width: 2.8vw;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0 0 7.5vw ;
   img {
     width: 3vw;
   }
@@ -193,6 +194,9 @@ const ExitButton = styled.button`
 const Counter = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 3.3vw;
+  position: absolute;
+  left: 50%; 
+  transform: translateX(-50%);
 `;
 
 const Content = styled.div`

--- a/src/pages/PersonGamePage.jsx
+++ b/src/pages/PersonGamePage.jsx
@@ -161,7 +161,7 @@ const Counter = styled.div`
   font-size: 3.3vw;
   position: absolute;
   left: 50%; 
-  transform: translateX(-50%);\
+  transform: translateX(-50%);
 `;
 
 const Content = styled.div`

--- a/src/pages/PersonGamePage.jsx
+++ b/src/pages/PersonGamePage.jsx
@@ -99,13 +99,13 @@ const PersonGamePage = () => {
         <div style={{ width: '48px' }} />
       </Header>
       <Content>
-        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0}>
+        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0} chevron="left">
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
           <Card src={cards[currentCardIndex].name} alt="person" />
         </CardContainer>
-        <NavButton onClick={handleNext}>
+        <NavButton onClick={handleNext} chevron="right">
           <img src="/images/icon_chevron_right.png" alt="next" />
         </NavButton>
       </Content>
@@ -142,14 +142,15 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7.1vh 7.5vw 0 7.5vw;
+  padding: 7.5vh 0 0 0;
 `;
 
 const ExitButton = styled.button`
+  width: 2.8vw;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0 0 7.5vw ;
   img {
     width: 3vw;
   }
@@ -158,6 +159,9 @@ const ExitButton = styled.button`
 const Counter = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 3.3vw;
+  position: absolute;
+  left: 50%; 
+  transform: translateX(-50%);\
 `;
 
 const Content = styled.div`
@@ -170,10 +174,15 @@ const NavButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  position: absolute;
+
   img {
-    width: 5vw;
+    height: 9.3vh;
   }
+    
+  ${(props) => props.chevron === 'left' && `left: 8vw;`}
+  ${(props) => props.chevron === 'right' && `right: 8vw;`}
+
   &:disabled {
     cursor: default;
     opacity: 0.5;
@@ -181,15 +190,14 @@ const NavButton = styled.button`
 `;
 
 const CardContainer = styled.div`
-  width: 57vw;
-  height: 67vh;
+  height: 55vh;
   display: flex;
+padding: 6.1vh 0 0 0;
   align-items: center;
   justify-content: center;
 `;
 
 const Card = styled.img`
-  width: 100%;
   height: 100%;
   object-fit: contain;
   display: block;
@@ -200,7 +208,8 @@ const AnswerContainer = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-`;  
+  padding: 5.1vh 0 0 0;
+`;
 
 const AnswerButton = styled.button`
   width: 19.5vw;

--- a/src/pages/PersonGamePage.jsx
+++ b/src/pages/PersonGamePage.jsx
@@ -175,6 +175,8 @@ const NavButton = styled.button`
   border: none;
   cursor: pointer;
   position: absolute;
+  top: 50%; 
+  transform: translateY(-50%);
 
   img {
     height: 9.3vh;
@@ -192,7 +194,7 @@ const NavButton = styled.button`
 const CardContainer = styled.div`
   height: 55vh;
   display: flex;
-padding: 6.1vh 0 0 0;
+  padding: 6.1vh 0 0 0;
   align-items: center;
   justify-content: center;
 `;

--- a/src/pages/ReadyPage.jsx
+++ b/src/pages/ReadyPage.jsx
@@ -1,12 +1,18 @@
-
 import React from 'react';
+import styled from 'styled-components';
 
 const ReadyPage = () => {
-  return (
-    <div>
-      <h1>Please make your screen wider</h1>
-    </div>
-  );
+  return (<Container />);
 };
 
 export default ReadyPage;
+
+
+const Container = styled.div`
+  background-image: url('/images/ready.png'), url('/images/home.gif');
+  background-size: contain, cover;
+  width: 100vw;
+  height: 100vh;
+  background-position: center, center;
+  background-repeat: no-repeat, no-repeat;
+`;

--- a/src/pages/TeleGamePage.jsx
+++ b/src/pages/TeleGamePage.jsx
@@ -122,14 +122,15 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7.1vh 7.5vw 0 7.5vw;
+  padding: 7.5vh 0 0 0;
 `;
 
 const ExitButton = styled.button`
+  width: 2.8vw;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0 0 7.5vw ;
   img {
     width: 3vw;
   }
@@ -138,6 +139,9 @@ const ExitButton = styled.button`
 const Counter = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 3.3vw;
+  position: absolute;
+  left: 50%; 
+  transform: translateX(-50%);
 `;
 
 const Content = styled.div`

--- a/src/pages/TeleGamePage.jsx
+++ b/src/pages/TeleGamePage.jsx
@@ -148,7 +148,6 @@ const Content = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-grow: 1;
 `;
 
 const NavButton = styled.button`
@@ -156,6 +155,8 @@ const NavButton = styled.button`
   border: none;
   cursor: pointer;
   position: absolute;
+  top: 50%; 
+  transform: translateY(-50%);
 
   img {
     height: 9.3vh;
@@ -171,13 +172,12 @@ const NavButton = styled.button`
 `;
 
 const CardContainer = styled.div`
-  width: 63vw;
-  height: 40vh;
+  width: 15.7vw;
+  height: 24.2vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 20px;
+  padding: 25.7vh 0 0 0;
 `;
 
 const Card = styled.div`

--- a/src/pages/TeleGamePage.jsx
+++ b/src/pages/TeleGamePage.jsx
@@ -90,13 +90,13 @@ const TeleGamePage = () => {
         <div style={{ width: '48px' }} />
       </Header>
       <Content>
-        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0}>
+        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0} chevron="left">
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
           <Card>{cards[currentCardIndex].name}</Card>
         </CardContainer>
-        <NavButton onClick={handleNext}>
+        <NavButton onClick={handleNext} chevron="right">
           <img src="/images/icon_chevron_right.png" alt="next" />
         </NavButton>
       </Content>
@@ -155,10 +155,15 @@ const NavButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  position: absolute;
+
   img {
-    width: 5vw;
+    height: 9.3vh;
   }
+    
+  ${(props) => props.chevron === 'left' && `left: 8vw;`}
+  ${(props) => props.chevron === 'right' && `right: 8vw;`}
+
   &:disabled {
     cursor: default;
     opacity: 0.5;

--- a/src/pages/TelestrationGamePage.jsx
+++ b/src/pages/TelestrationGamePage.jsx
@@ -137,14 +137,15 @@ const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 7.1vh 7.5vw 0 7.5vw;
+  padding: 7.5vh 0 0 0;
 `;
 
 const ExitButton = styled.button`
+  width: 2.8vw;
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  padding: 0 0 0 7.5vw ;
   img {
     width: 3vw;
   }
@@ -153,6 +154,9 @@ const ExitButton = styled.button`
 const Counter = styled.div`
   font-family: 'DungGeunMo', sans-serif;
   font-size: 3.3vw;
+  position: absolute;
+  left: 50%; 
+  transform: translateX(-50%);
 `;
 
 const Content = styled.div`

--- a/src/pages/TelestrationGamePage.jsx
+++ b/src/pages/TelestrationGamePage.jsx
@@ -102,7 +102,7 @@ const TelestrationGamePage = () => {
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
-          <Card>
+          <Card isAnswered={isAnswered}>
             {isAnswered
               ? '게임 진행 중 ...'
               : cards[currentCardIndex].name}
@@ -163,7 +163,6 @@ const Content = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  flex-grow: 1;
 `;
 
 const NavButton = styled.button`
@@ -171,6 +170,8 @@ const NavButton = styled.button`
   border: none;
   cursor: pointer;
   position: absolute;
+  top: 50%; 
+  transform: translateY(-50%);
 
   img {
     height: 9.3vh;
@@ -187,24 +188,23 @@ const NavButton = styled.button`
 
 const CardContainer = styled.div`
   width: 70vw;
-  height: 40vh;
+  height: 18.7vh;
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: rgba(0, 0, 0, 0.5);
-  border-radius: 20px;
+  padding: 27vh 0 0 0;
 `;
 
 const Card = styled.div`
   font-family: 'DungGeunMo', sans-serif;
-  font-size: 11vw;
-  color: white;
+  font-size: ${(props) => (props.isAnswered ? '8vw' : '11vw')};
+  color: ${(props) => (props.isAnswered ? '#ff62d3' : 'white')};
   white-space: pre-wrap;
   text-align: center;
 `;
 
 const AnswerButton = styled.button`
-  width: 17.3vw;
+  width: 19.5vw;
   height: 8.5vh;
   background-color: ${(props) => (props.isAnswered ? 'white' : '#ff62d3')};
   border: none;
@@ -213,5 +213,5 @@ const AnswerButton = styled.button`
   font-size: 3vw;
   color: black;
   cursor: pointer;
-  margin-bottom: 10vh;
+  margin-top: 19.5vh;
 `;

--- a/src/pages/TelestrationGamePage.jsx
+++ b/src/pages/TelestrationGamePage.jsx
@@ -98,7 +98,7 @@ const TelestrationGamePage = () => {
         <div style={{ width: '48px' }} />
       </Header>
       <Content>
-        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0}>
+        <NavButton onClick={handlePrev} disabled={currentCardIndex === 0} chevron="left">
           <img src="/images/icon_chevron_left_white.png" alt="prev" />
         </NavButton>
         <CardContainer>
@@ -108,7 +108,7 @@ const TelestrationGamePage = () => {
               : cards[currentCardIndex].name}
           </Card>
         </CardContainer>
-        <NavButton onClick={handleNext}>
+        <NavButton onClick={handleNext} chevron="right">
           <img src="/images/icon_chevron_right.png" alt="next" />
         </NavButton>
       </Content>
@@ -170,10 +170,15 @@ const NavButton = styled.button`
   background: none;
   border: none;
   cursor: pointer;
-  padding: 0;
+  position: absolute;
+
   img {
-    width: 5vw;
+    height: 9.3vh;
   }
+    
+  ${(props) => props.chevron === 'left' && `left: 8vw;`}
+  ${(props) => props.chevron === 'right' && `right: 8vw;`}
+
   &:disabled {
     cursor: default;
     opacity: 0.5;


### PR DESCRIPTION
### 📕 Issue Number

Close #3 
Close #5 


### 📙 작업 내역

> 구현 내용 및 작업 했던 내역

- [x] UI 수정
- [x] 반응형 화면 UI 갈아끼우기


### 📱 스크린샷

> UI 구현 혹은 화면 변동이 있는 PR이라면 스크린샷 첨부
<img width="1062" height="851" alt="스크린샷 2025-10-06 오전 2 07 07" src="https://github.com/user-attachments/assets/c079fb7f-059f-429d-9c8a-4f39d0dbfbff" />

<img width="1515" height="725" alt="스크린샷 2025-10-06 오전 2 07 23" src="https://github.com/user-attachments/assets/0e571d4e-e5de-4577-b2c7-8f6c7f91aa59" />

<img width="1527" height="743" alt="스크린샷 2025-10-06 오전 2 07 34" src="https://github.com/user-attachments/assets/80652369-e17e-4845-bb06-c36e70413220" />

<img width="1502" height="720" alt="스크린샷 2025-10-06 오전 2 07 44" src="https://github.com/user-attachments/assets/7ab6b9b1-2b13-42f4-8f05-1f58b2b74728" />


 


<br/><br/>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Directional navigation arrows (left/right chevrons) across game pages for clearer navigation.
  - Standardized Exit button in headers.
  - Ready screen now uses full-viewport themed background images.
  - Cards visually reflect answered state on applicable pages.
  - Counters centered at the top for improved readability.

- Style
  - Unified header padding and layout.
  - Adjusted card/container sizes and spacing; answer buttons widened and repositioned.
  - Vertically centered, absolutely positioned nav buttons.
  - Refined category layout spacing and added subtle borders/rounding for buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->