### PR TITLE
[Style] UI 수정

### DIFF
--- a/src/components/onboarding/Onboarding.jsx
+++ b/src/components/onboarding/Onboarding.jsx
@@ -125,6 +125,7 @@ const InstructionIndex = styled.p`
   font-weight: 400;
   margin: 0;
   margin-right: 10px;
+  margin-top: 11px;
 `;
 
 const InstructionText = styled.p`
@@ -134,4 +135,6 @@ const InstructionText = styled.p`
   font-weight: 400;
   margin: 0;
   white-space: pre-wrap;
+  margin-top: 7px;
+  line-height: 1.4;
 `;

--- a/src/pages/GameOver.jsx
+++ b/src/pages/GameOver.jsx
@@ -139,5 +139,5 @@ const FeedbackLink = styled.a`
   color: white;
   text-decoration: underline;
   position: absolute;
-  bottom: 50px;
+  bottom: 120px;
 `;

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -45,7 +45,7 @@ const Home = () => {
       navigate(gameData[selectedGame].route);
     }
   };
-  
+
 
   if (windowWidth < 1126 || windowHeight < 627) {
     return <ReadyPage />;
@@ -110,10 +110,9 @@ const Header = styled.div`
 `;
 
 const TitleImage = styled.img`
-  width: 13.5vw;
-  height: 5vh;
+  width: 16vw;
   cursor: pointer;
-  margin-left: 9.5vw;
+  margin-left: 8.5vw;
 `;
 
 const ButtonContainer = styled.div`
@@ -141,5 +140,5 @@ const Content = styled.div`
   justify-content: flex-start;
   align-items: flex-start;
   margin-left: 7.5vw;
-  gap: 6.3vw;
+  gap: 8vw;
 `;

--- a/src/pages/MovieGamePage.jsx
+++ b/src/pages/MovieGamePage.jsx
@@ -228,7 +228,7 @@ const CardImage = styled.img`
 `;
 
 const AnswerText = styled.p`
-  height: 12.9vh;
+  width: 75vw;
   font-family: 'DungGeunMo', sans-serif;
   font-size: 6vw;
   color: #ff62d3;

--- a/src/pages/Splash.jsx
+++ b/src/pages/Splash.jsx
@@ -96,8 +96,8 @@ const TopSpacer = styled.div`
 `;
 
 const TitleImage = styled.img`
-  width: 54vw;
-  height: 19vh;
+  width: 65vw;
+  height: 20vh;
 `;
 
 const BottomSpacer = styled.div`


### PR DESCRIPTION
Close #25 
 - 스플래시 로고 비율 수정
 - 홈 로고 비율, 설명 간격 수정
 - 명대사퀴즈 밀리는 거 수정
 - 게임오버 사알짝 수정
 
<img width="1710" height="1107" alt="스크린샷 2025-10-15 오후 6 30 11" src="https://github.com/user-attachments/assets/9db25d2c-7ab7-4a2c-9be1-995cd4d23c3e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual spacing in onboarding instructions for better readability.
  * Adjusted TitleImage sizes on Home and Splash for more balanced layout.
  * Increased content gap on Home and refined TitleImage positioning.
  * Updated AnswerText sizing on Movie Game page to improve layout flow.
  * Moved Feedback link higher on Game Over screen for clearer visibility.
  * General margin and line-height tweaks across components; no functional changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->